### PR TITLE
fix(ui): keep section tabs usable on read-only sheets

### DIFF
--- a/src/module/applications/feat-sheet.ts
+++ b/src/module/applications/feat-sheet.ts
@@ -1,3 +1,4 @@
+import * as SheetHelpers from '../helpers/sheet-helpers.js';
 import { WEAPON_TYPES } from '../models/item-feat.js';
 import * as ItemSearch from '../../../item-search.js';
 import { DELAYS } from '../config/constants.js';
@@ -238,6 +239,11 @@ export class FeatSheet extends ItemSheet {
         }
       });
     }, { signal });
+
+    // Section tabs are <button>: FormApplication#_disableFields disables them on
+    // a non-editable sheet (an item in a locked compendium), which would leave
+    // navigation dead. They only switch the visible section, so restore them.
+    SheetHelpers.enableSectionNavigation(html);
   }
   
   /**

--- a/src/module/applications/vehicle-sheet.ts
+++ b/src/module/applications/vehicle-sheet.ts
@@ -615,6 +615,11 @@ export class VehicleSheet extends ActorSheet {
         SheetHelpers.restoreActiveSection(form, activeSection);
       }
     }));
+
+    // Section tabs are <button>: FormApplication#_disableFields disables them on
+    // a non-editable sheet, which would leave navigation dead. They only switch
+    // the visible section, so restore them.
+    SheetHelpers.enableSectionNavigation(html);
   }
 
   /**

--- a/src/module/helpers/sheet-helpers.ts
+++ b/src/module/helpers/sheet-helpers.ts
@@ -1217,6 +1217,36 @@ export function getCurrentActiveSection(html: JQuery | HTMLElement): string | nu
   return activeNavItem ? (activeNavItem.dataset.section || null) : null;
 }
 
+/**
+ * Re-enable the section-navigation buttons of a non-editable sheet.
+ *
+ * When a sheet is not editable — an item opened from a locked compendium being
+ * the common case — `FormApplication#_disableFields` runs from
+ * `super.activateListeners()` and sets `disabled` on every descendant
+ * `input`, `select`, `textarea` **and `button`**.
+ *
+ * The section tabs are `<button class="nav-item">` elements, so they are
+ * disabled along with the genuine form controls: the sheet opens stuck on its
+ * first section and the tabs do not respond, with nothing logged to explain it.
+ *
+ * These buttons only toggle which section is visible; they never mutate the
+ * document, so re-enabling them restores navigation while leaving the sheet
+ * exactly as read-only as before.
+ *
+ * Must be called *after* `super.activateListeners()`, which is what disables
+ * them.
+ *
+ * @param html - The sheet's root element.
+ */
+export function enableSectionNavigation(html: JQuery | HTMLElement): void {
+  const el = html instanceof HTMLElement ? html : html[0] as HTMLElement;
+  if (!el) return;
+  el.querySelectorAll<HTMLButtonElement>('.section-nav .nav-item[disabled]')
+    .forEach(button => {
+      button.disabled = false;
+    });
+}
+
 // ============================================================================
 // FEAT ENRICHMENT
 // ============================================================================


### PR DESCRIPTION
Sur une fiche d'atout ou de véhicule non éditable, typiquement un item ouvert depuis un compendium verrouillé, les onglets de section ne répondent plus. La fiche reste bloquée sur sa première section, sans rien en console pour l'expliquer.

Ceci est causé par le fait que ces fiches sont en ApplicationV1 : `super.activateListeners` appelle `FormApplication._disableFields`, qui pose `disabled` sur tous les input, select, textarea et button descendants. Or les onglets sont des `<button class="nav-item">` (`item-feat-sheet.hbs:34-80` et `actor-vehicle-sheet.hbs:60-67`), donc ils sont désactivés avec les vrais champs et un clic ne déclenche jamais le handler.

Ces boutons ne font que changer la section visible, ils ne modifient jamais le document. On les réactive après `_disableFields`, de manière à rendre la navigation sans rendre la fiche éditable : tous les vrais champs restent désactivés. `SheetHelpers.enableSectionNavigation` est ajouté à côté des helpers de navigation existants, et appelé dans les deux fiches qui ont une `.section-nav`.

NB : `character-sheet.ts` bind aussi `.section-nav .nav-item`, mais son template `actor-character-sheet.hbs` est absent de `public/templates`. Je l'ai laissé de côté, dis-moi s'il faut le traiter aussi.
