### PR TITLE
fix(style): apply theme variables without requiring a core theme class

### DIFF
--- a/src/less/themes/sra2.less
+++ b/src/less/themes/sra2.less
@@ -80,12 +80,23 @@
   @sheet-background: "/systems/sra2/img/interface/sra2/sra2_background_window_dark.webp";
 
 
-  //Apply cation of common theme variables
-  body.sr-theme-sra2.theme-dark {
-    .theme-vars();
-  }
-
-  body.sr-theme-sra2.theme-light {
+  // Application of common theme variables.
+  //
+  // Bound to body.sr-theme-sra2 alone, deliberately without a core theme class.
+  // Foundry clears theme-light/theme-dark from <body> when the client's theme
+  // setting is "Default" and the browser reports no colour-scheme preference,
+  // and these variables have to survive that: styles such as
+  // .sra2-item-sheet's `linear-gradient(..., var(--sr-ui-bg-color-dark), ...)`
+  // resolve to an invalid gradient once the variables are undefined, which —
+  // combined with the global `.window-content { background: none }` — leaves
+  // sheets with no background at all.
+  //
+  // .theme-vars() is theme-agnostic, so the two former rules
+  // (body.sr-theme-sra2.theme-dark and .theme-light) emitted identical
+  // declarations; collapsing them to the shared selector changes nothing in
+  // either theme and only adds the no-theme-class case. Theme-specific
+  // overrides, if ever needed, can still be layered on top.
+  body.sr-theme-sra2 {
     .theme-vars();
   }
 }


### PR DESCRIPTION
Les variables du thème SRA2 ne sont émises que sous `body.sr-theme-sra2.theme-dark` et `body.sr-theme-sra2.theme-light` (`src/less/themes/sra2.less:84,88`). Il faut donc que le body porte à la fois `sr-theme-sra2` et une classe de thème du coeur pour qu'une seule de ces variables existe.

Lorsque le réglage de thème du client est sur Default et que le navigateur ne renvoie aucune préférence, Foundry retire `theme-light` et `theme-dark` du body. Dans cet état plus aucune variable n'est définie : le `linear-gradient` de `.sra2-item-sheet` (`item-sheet.scss:154`) devient invalide, et comme `global.scss:23` pose `.window-content { background: none }`, les fiches se retrouvent sans aucun fond.

`.theme-vars` ne dépend d'aucun thème, les deux règles émettaient donc des déclarations identiques. On les fusionne sur `body.sr-theme-sra2`, ce qui produit exactement les mêmes variables en clair comme en sombre, et couvre en plus le cas sans classe de thème. Des surcharges par thème restent possibles par-dessus si le besoin apparaît.

NB : le symptôme du fond manquant n'a été observé qu'une fois et a disparu avant inspection du DOM, donc le déclencheur exact n'est pas confirmé. Le changement se tient indépendamment : il est neutre dans les deux thèmes et supprime une dépendance à une classe que le coeur peut légitimement ne pas poser.
