### PR TITLE
fix: run migrations sequentially and stamp the version after they finish

### DIFF
--- a/src/module/__tests__/migration-runner.test.ts
+++ b/src/module/__tests__/migration-runner.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Regression tests for the migration runner sequencing.
+ *
+ * Two defects these guard against:
+ *  - `migrations.forEach(async m => await m.migrate())` started every migration
+ *    at once, so sorting them by version had no effect on execution order
+ *  - CURRENT_SYSTEM_VERSION was written before any migration had finished, so a
+ *    world interrupted mid-migration was marked up to date for good
+ */
+
+/** Ordered log of everything the runner does, shared by the doubles below */
+let journal: string[];
+let currentVersion: string;
+
+/** Migration double logging its start and end, slow in proportion to `steps` */
+function makeMigration(version: string, steps: number) {
+  return {
+    code: `migration-${version}`,
+    version,
+    migrate: async () => {
+      journal.push(`${version}:start`);
+      for (let i = 0; i < steps; i++) await Promise.resolve();
+      journal.push(`${version}:end`);
+    },
+  };
+}
+
+/** Install a Hooks double serving these migrations to the runner */
+function serve(...migrations: any[]) {
+  (globalThis as any).Hooks = {
+    callAll: (_event: string, declare: (...list: any[]) => void) => declare(...migrations),
+    off: () => {},
+  };
+}
+
+/** Load the runner. migration.mjs is plain JS, it ships no declaration file. */
+async function loadRunner(): Promise<any> {
+  // @ts-ignore - untyped .mjs module, same as its imports in sra2-system.ts
+  const mod = await import('../migration/migration.mjs');
+  return mod.Migrations;
+}
+
+beforeEach(() => {
+  journal = [];
+  currentVersion = '13.0.0';
+  (globalThis as any).SYSTEM = { id: 'sra2', LOG: { HEAD: '' } };
+  (globalThis as any).ui = { notifications: { info: () => {} } };
+  (globalThis as any).foundry = {
+    utils: {
+      isNewerVersion: (a: string, b: string) => {
+        const pa = String(a).split('.').map(Number);
+        const pb = String(b).split('.').map(Number);
+        for (let i = 0; i < 3; i++) {
+          if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+          if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+        }
+        return false;
+      },
+    },
+  };
+  (globalThis as any).game = {
+    system: { version: '14.4.0' },
+    i18n: { format: (k: string) => k, localize: (k: string) => k },
+    settings: {
+      register: () => {},
+      get: () => currentVersion,
+      set: (_id: string, _key: string, value: string) => {
+        currentVersion = value;
+        journal.push('version:stamped');
+      },
+    },
+  };
+});
+
+afterEach(() => {
+  for (const k of ['SYSTEM', 'ui', 'foundry', 'game', 'Hooks']) delete (globalThis as any)[k];
+});
+
+describe('Migrations.migrate', () => {
+  it('runs migrations one after another, in version order', async () => {
+    // the older migration is the slow one: were they to overlap, the newer would finish first
+    serve(makeMigration('13.4.0', 1), makeMigration('13.2.4', 8));
+
+    const Migrations = await loadRunner();
+    await new Migrations().migrate();
+
+    expect(journal).toEqual([
+      '13.2.4:start', '13.2.4:end',
+      '13.4.0:start', '13.4.0:end',
+      'version:stamped',
+    ]);
+  });
+
+  it('stamps the system version only once every migration has finished', async () => {
+    serve(makeMigration('13.2.4', 8), makeMigration('13.4.0', 1));
+
+    const Migrations = await loadRunner();
+    await new Migrations().migrate();
+
+    expect(journal.at(-1)).toBe('version:stamped');
+    expect(journal.indexOf('version:stamped')).toBe(journal.length - 1);
+    expect(currentVersion).toBe('14.4.0');
+  });
+
+  it('leaves the version untouched when a migration throws, so it runs again next load', async () => {
+    serve({ code: 'boom', version: '13.5.0', migrate: async () => { throw new Error('boom'); } });
+
+    const Migrations = await loadRunner();
+    await expect(new Migrations().migrate()).rejects.toThrow('boom');
+
+    expect(journal).not.toContain('version:stamped');
+    expect(currentVersion).toBe('13.0.0');
+  });
+});

--- a/src/module/migration/migration.mjs
+++ b/src/module/migration/migration.mjs
@@ -10,14 +10,14 @@ export class Migration {
   async migrate() { return () => { } };
 
   async applyItemsUpdates(computeUpdates = (items) => []) {
-    await game.actors.forEach(async (actor) => {
+    for (const actor of game.actors) {
       const actorItemUpdates = computeUpdates(actor.items);
       if (actorItemUpdates.length > 0) {
         const message = game.i18n.format('SRA2.MIGRATION.APPLYING_ACTOR_ITEMS', { name: actor.name });
         console.log(SYSTEM.LOG.HEAD, this.code, message, actorItemUpdates);
         await actor.updateEmbeddedDocuments('Item', actorItemUpdates);
       }
-    })
+    }
 
     const itemUpdates = computeUpdates(game.items);
     if (itemUpdates.length > 0) {
@@ -43,7 +43,7 @@ export class Migrations {
     })
   }
 
-  migrate() {
+  async migrate() {
     const currentVersion = game.settings.get(SYSTEM.id, CURRENT_SYSTEM_VERSION)
     if (foundry.utils.isNewerVersion(game.system.version, currentVersion)) {
       //if (true) {
@@ -55,11 +55,11 @@ export class Migrations {
 
       if (migrations.length > 0) {
         migrations.sort((a, b) => foundry.utils.isNewerVersion(a.version, b.version) ? 1 : foundry.utils.isNewerVersion(b.version, a.version) ? -1 : 0)
-        migrations.forEach(async m => {
+        for (const m of migrations) {
           const message = game.i18n.format('SRA2.MIGRATION.EXECUTING', { code: m.code, currentVersion: currentVersion, targetVersion: m.version });
           this.$notify(message);
           await m.migrate()
-        })
+        }
         const message = game.i18n.format('SRA2.MIGRATION.DONE', { version: game.system.version });
         this.$notify(message)
       }

--- a/src/module/sra2-system.ts
+++ b/src/module/sra2-system.ts
@@ -1910,7 +1910,7 @@ export class SRA2System {
 
     // Run migrations
     const migrations = new Migrations();
-    migrations.migrate();
+    await migrations.migrate();
 
     // Migrate old feat data to new array format (deprecated, keeping for older versions)
     await this.migrateFeatsToArrayFormat();


### PR DESCRIPTION
Les migrations sont lancées par un [`forEach(async ...)`](https://github.com/VincentVk9373/sra2/blob/0c07cf9a028b833f3f2b9a93d7ca0da304935fec/src/module/migration/migration.mjs#L58-L62) qui ignore les promesses retournées : elles démarrent toutes en même temps, et le [`sort`](https://github.com/VincentVk9373/sra2/blob/0c07cf9a028b833f3f2b9a93d7ca0da304935fec/src/module/migration/migration.mjs#L57) par version qui les précède n'a aucun effet sur l'ordre d'exécution. Le [`game.settings.set(CURRENT_SYSTEM_VERSION, ...)`](https://github.com/VincentVk9373/sra2/blob/0c07cf9a028b833f3f2b9a93d7ca0da304935fec/src/module/migration/migration.mjs#L70) qui suit s'exécute avant qu'aucune ne soit terminée, donc un monde interrompu en cours de migration est estampillé à jour définitivement et ne rejouera jamais.

On passe à `for (const m of migrations)` avec `await` dans le corps, de manière à ce que les migrations s'enchaînent dans l'ordre des versions et que la version ne soit posée qu'une fois toutes terminées. Si l'une lève, la version n'est plus posée du tout et le monde rejouera la migration au prochain chargement.

Même correction dans [`applyItemsUpdates`](https://github.com/VincentVk9373/sra2/blob/0c07cf9a028b833f3f2b9a93d7ca0da304935fec/src/module/migration/migration.mjs#L13), où `await game.actors.forEach(async ...)` attendait `undefined` : `Collection` étend `Map`, dont le `forEach` ne retourne rien. Les `updateEmbeddedDocuments` n'étaient donc pas attendus non plus.

`onReady` attend désormais `migrations.migrate()`, sans quoi les migrations déclarées couraient aussi contre les `migrateFeatsToArrayFormat` qui la suivent.

Trois tests couvrent l'enchaînement, le moment de la pose de version et le cas de la migration qui lève. Ils échouent tous les trois sur le code actuel.
